### PR TITLE
Add ability to parse CSV to Entry model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _data
 .DS_Store
+.idea

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/pkg/entry/entry.go
+++ b/pkg/entry/entry.go
@@ -1,7 +1,11 @@
 package entry
 
 import (
+	"bytes"
+	"encoding/csv"
 	"encoding/json"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -14,11 +18,88 @@ type entry struct {
 }
 
 type Entries struct {
-	Entries []entry `json:"entries"`
+	Entries []entry `json:"input"`
 }
 
-func ParseEntriesFromCSV(csv []byte) Entries {
-	return Entries{}
+var (
+	CsvHeaderIndex = 0
+	FullDateIndex = 0
+	TimeIndex = 3
+	MoodIndex = 4
+	ActivitiesIndex = 5
+	NoteTitleIndex = 6
+	NoteContentIndex = 7
+)
+
+func ParseEntriesFromCSV(csvData []byte) (Entries, error) {
+	records, err := csv.NewReader(bytes.NewReader(csvData)).ReadAll()
+
+	if err != nil {
+		return Entries{}, err
+	}
+
+	var entries []entry
+
+	for i, record := range records {
+		if i != CsvHeaderIndex {
+			date, err := parseDateFromEntry(record[FullDateIndex], record[TimeIndex])
+
+			if err != nil {
+				return Entries{}, nil
+			}
+
+			entries = append(entries, entry{
+				Date: date,
+				Mood: record[MoodIndex],
+				Activities: parseActivitiesFromEntry(record[ActivitiesIndex]),
+				NoteTitle: record[NoteTitleIndex],
+				Note: record[NoteContentIndex],
+			})
+		}
+	}
+
+	return Entries{Entries: entries}, nil
+}
+
+func parseDateFromEntry(date string, timeRecorded string) (time.Time, error) {
+	dateStrings := strings.Split(date, "-")
+	year, err := strconv.Atoi(dateStrings[0])
+	month, err := strconv.Atoi(dateStrings[1])
+	day, err := strconv.Atoi(dateStrings[2])
+
+	isAm := strings.Contains(timeRecorded, "am")
+	var hour, minute int
+	if isAm {
+		timeStrings := strings.Split(strings.Replace(timeRecorded, " am", "", 1), ":")
+		hour, err = strconv.Atoi(timeStrings[0])
+		minute, err = strconv.Atoi(timeStrings[1])
+	} else {
+		timeStrings := strings.Split(strings.Replace(timeRecorded, " pm", "", 1), ":")
+		hour, err = strconv.Atoi(timeStrings[0])
+		hour = (hour + 12) % 24
+		minute, err = strconv.Atoi(timeStrings[1])
+	}
+
+
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Date(year, time.Month(month), day, hour, minute, 0, 0, time.Local), nil
+}
+
+func parseActivitiesFromEntry(activities string) []string {
+	if activities == "" {
+		return []string{}
+	}
+	activitySplits := strings.Split(activities, "|")
+	var trimmedActivities []string
+
+	for _, activity := range activitySplits {
+		trimmedActivities = append(trimmedActivities, strings.TrimSpace(activity))
+	}
+
+	return trimmedActivities
 }
 
 func (e Entries) toString() (string, error) {

--- a/pkg/entry/entry.go
+++ b/pkg/entry/entry.go
@@ -1,0 +1,31 @@
+package entry
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type entry struct {
+	Date       time.Time `json:"date"`
+	Mood       string   `json:"mood"`
+	Activities []string `json:"activities"`
+	NoteTitle string `json:"note_title"`
+	Note      string `json:"note"`
+}
+
+type Entries struct {
+	Entries []entry `json:"entries"`
+}
+
+func ParseEntriesFromCSV(csv []byte) Entries {
+	return Entries{}
+}
+
+func (e Entries) toString() (string, error) {
+	serialised, err := json.Marshal(e)
+	if err != nil {
+		return "", err
+	}
+
+	return string(serialised), nil
+}

--- a/pkg/entry/entry_test.go
+++ b/pkg/entry/entry_test.go
@@ -6,45 +6,52 @@ import (
 	"time"
 )
 
-func TestParseCSV(t *testing.T) {
+func TestParseEntriesFromCSV(t *testing.T) {
 	t.Run("converts CSV correctly", func(t *testing.T) {
-		input := []byte("full_date,Date,weekday,time,Mood,Activities,note_title,Note\n2021-10-18,18 October,Monday,11:25 pm,Energised,\"home | appreciate\",\"\",\"\"")
-		expected := Entries{Entries: []entry{
-			{
-				Date:       time.Date(2021,10,18,11,25, 0, 0, time.Local),
-				Mood:       "Energized",
-				Activities: []string{"home", "appreciate"},
-				NoteTitle:  "",
-				Note:       "",
-			},
-		}}
-		result := ParseEntriesFromCSV(input)
+		amRecordCsv := []byte("full_date,Date,weekday,time,Mood,Activities,note_title,Note\n2021-10-18,18 October,Monday,11:25 am,Energised,\"home | appreciate\",\"\",\"\"")
+		amRecords := Entries{[]entry{{time.Date(2021,10,18,11,25, 0, 0, time.Local), "Energised", []string{"home", "appreciate"}, "", ""}}}
 
-		expectedString, _ := expected.toString()
-		resultString, _ := result.toString()
+		pmRecordCsv := []byte("full_date,Date,weekday,time,Mood,Activities,note_title,Note\n2021-10-18,18 October,Monday,11:25 pm,Energised,\"home | appreciate\",\"\",\"\"")
+		pmRecords := Entries{[]entry{{time.Date(2021,10,18,23,25, 0, 0, time.Local), "Energised", []string{"home", "appreciate"}, "", ""}}}
 
-		if expectedString != resultString {
-			t.Fatalf("expected: %s\ngot: %s\n", expectedString, resultString)
+		noActivityRecordsCsv := []byte("full_date,Date,weekday,time,Mood,Activities,note_title,Note\n2021-10-18,18 October,Monday,11:25 pm,Energised,\"\",\"\",\"\"")
+		noActivityRecords := Entries{[]entry{{time.Date(2021,10,18,23,25, 0, 0, time.Local), "Energised", []string{}, "", ""}}}
+
+		noteRecordsCsv := []byte("full_date,Date,weekday,time,Mood,Activities,note_title,Note\n2021-10-18,18 October,Monday,11:25 pm,Energised,\"home | appreciate\",\"\",\"Today I wrote some tests\"")
+		noteRecords := Entries{[]entry{{time.Date(2021,10,18,23,25, 0, 0, time.Local), "Energised", []string{"home", "appreciate"}, "", "Today I wrote some tests"}}}
+
+		tests := []struct {
+			name     string
+			input    []byte
+			expected Entries
+		}{
+			{"parses entry recorded in am", amRecordCsv, amRecords},
+			{"parses entry recorded in pm", pmRecordCsv, pmRecords},
+			{"parses entry with no activities", noActivityRecordsCsv, noActivityRecords},
+			{"parses entry with a note", noteRecordsCsv, noteRecords},
+		}
+		for _, testcase := range tests {
+			t.Run(testcase.name, func(t *testing.T) {
+				result, _ := ParseEntriesFromCSV(testcase.input)
+				expectedString, _ := testcase.expected.toString()
+				if got, _ := result.toString(); got != expectedString {
+					t.Errorf("recieved %v\n expected %v", result, testcase.expected)
+				}
+			})
 		}
 	})
 }
 
 func TestEntries_toString(t *testing.T) {
 	date := time.Date(2021,10,18,11,25, 0, 0, time.Local)
-	withActivities := Entries{Entries: []entry{
-		{date, "Energized", []string{"home", "appreciate"}, "", ""},
-	}}
-	withoutActivities := Entries{Entries: []entry{
-		{date, "Energized", []string{}, "", ""},
-	}}
-	withNote := Entries{Entries: []entry{
-		{date, "Energized", []string{}, "Note's title", "Note's content"},
-	}}
+	withActivities := Entries{[]entry{{date, "Energized", []string{"home", "appreciate"}, "", ""}}}
+	withoutActivities := Entries{[]entry{{date, "Energized", []string{}, "", ""}}}
+	withNote := Entries{[]entry{{date, "Energized", []string{}, "Note's title", "Note's content"}}}
 
 	dateString, _ := date.MarshalJSON()
-	withActivitiesString := fmt.Sprintf(`{"entries":[{"date":%s,"mood":"Energized","activities":["home","appreciate"],"note_title":"","note":""}]}`, dateString)
-	withoutActivitiesString := fmt.Sprintf(`{"entries":[{"date":%s,"mood":"Energized","activities":[],"note_title":"","note":""}]}`, dateString)
-	withNoteString := fmt.Sprintf(`{"entries":[{"date":%s,"mood":"Energized","activities":[],"note_title":"Note's title","note":"Note's content"}]}`, dateString)
+	withActivitiesString := fmt.Sprintf(`{"input":[{"date":%s,"mood":"Energized","activities":["home","appreciate"],"note_title":"","note":""}]}`, dateString)
+	withoutActivitiesString := fmt.Sprintf(`{"input":[{"date":%s,"mood":"Energized","activities":[],"note_title":"","note":""}]}`, dateString)
+	withNoteString := fmt.Sprintf(`{"input":[{"date":%s,"mood":"Energized","activities":[],"note_title":"Note's title","note":"Note's content"}]}`, dateString)
 
 	tests := []struct {
 		name string
@@ -59,7 +66,7 @@ func TestEntries_toString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := tt.json
 			if got, _ := d.toString(); got != tt.want {
-				t.Errorf("toString() = %v, want %v", got, tt.want)
+				t.Errorf("toString() = %v, expected %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/entry/entry_test.go
+++ b/pkg/entry/entry_test.go
@@ -1,0 +1,66 @@
+package entry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestParseCSV(t *testing.T) {
+	t.Run("converts CSV correctly", func(t *testing.T) {
+		input := []byte("full_date,Date,weekday,time,Mood,Activities,note_title,Note\n2021-10-18,18 October,Monday,11:25 pm,Energised,\"home | appreciate\",\"\",\"\"")
+		expected := Entries{Entries: []entry{
+			{
+				Date:       time.Date(2021,10,18,11,25, 0, 0, time.Local),
+				Mood:       "Energized",
+				Activities: []string{"home", "appreciate"},
+				NoteTitle:  "",
+				Note:       "",
+			},
+		}}
+		result := ParseEntriesFromCSV(input)
+
+		expectedString, _ := expected.toString()
+		resultString, _ := result.toString()
+
+		if expectedString != resultString {
+			t.Fatalf("expected: %s\ngot: %s\n", expectedString, resultString)
+		}
+	})
+}
+
+func TestEntries_toString(t *testing.T) {
+	date := time.Date(2021,10,18,11,25, 0, 0, time.Local)
+	withActivities := Entries{Entries: []entry{
+		{date, "Energized", []string{"home", "appreciate"}, "", ""},
+	}}
+	withoutActivities := Entries{Entries: []entry{
+		{date, "Energized", []string{}, "", ""},
+	}}
+	withNote := Entries{Entries: []entry{
+		{date, "Energized", []string{}, "Note's title", "Note's content"},
+	}}
+
+	dateString, _ := date.MarshalJSON()
+	withActivitiesString := fmt.Sprintf(`{"entries":[{"date":%s,"mood":"Energized","activities":["home","appreciate"],"note_title":"","note":""}]}`, dateString)
+	withoutActivitiesString := fmt.Sprintf(`{"entries":[{"date":%s,"mood":"Energized","activities":[],"note_title":"","note":""}]}`, dateString)
+	withNoteString := fmt.Sprintf(`{"entries":[{"date":%s,"mood":"Energized","activities":[],"note_title":"Note's title","note":"Note's content"}]}`, dateString)
+
+	tests := []struct {
+		name string
+		json Entries
+		want string
+	}{
+		{"serialises to a string", withActivities, withActivitiesString},
+		{"serialises to a string without Activities", withoutActivities, withoutActivitiesString},
+		{"serialises to a string with Note", withNote, withNoteString},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := tt.json
+			if got, _ := d.toString(); got != tt.want {
+				t.Errorf("toString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/testlist.md
+++ b/testlist.md
@@ -4,9 +4,10 @@ A collection of test cases I think of as I develop the Jaylio API.
 
 Inspired by the method showcased in Kent Beck's Test Driven Development: By Example, I thought I'd give it a try
 
-- [ ] can parse CSV to JSON
-- [ ] can parse CSV with no activities to JSON
-- [ ] can parse CSV with note to JSON
-- [x] can serialise JSON to string
-- [x] can serialise JSON without activities to string
-- [x] can serialise JSON with note to string
+- [x] can parse CSV to Model
+- [x] can parse CSV to Model with am or pm time
+- [x] can parse CSV with no activities to Model
+- [x] can parse CSV with note to Model
+- [x] can serialise Model to string
+- [x] can serialise Model without activities to string
+- [x] can serialise Model with note to string

--- a/testlist.md
+++ b/testlist.md
@@ -7,6 +7,6 @@ Inspired by the method showcased in Kent Beck's Test Driven Development: By Exam
 - [ ] can parse CSV to JSON
 - [ ] can parse CSV with no activities to JSON
 - [ ] can parse CSV with note to JSON
-- [ ] can serialise JSON to string
-- [ ] can serialise JSON without activities to string
-- [ ] can serialise JSON with note to string
+- [x] can serialise JSON to string
+- [x] can serialise JSON without activities to string
+- [x] can serialise JSON with note to string

--- a/testlist.md
+++ b/testlist.md
@@ -1,0 +1,12 @@
+# Test List
+
+A collection of test cases I think of as I develop the Jaylio API. 
+
+Inspired by the method showcased in Kent Beck's Test Driven Development: By Example, I thought I'd give it a try
+
+- [ ] can parse CSV to JSON
+- [ ] can parse CSV with no activities to JSON
+- [ ] can parse CSV with note to JSON
+- [ ] can serialise JSON to string
+- [ ] can serialise JSON without activities to string
+- [ ] can serialise JSON with note to string


### PR DESCRIPTION
- Added `Entries` struct to help model the Daylio data
- Added `toString` fn to run on an `Entries` receiver with test coverage
- Added `ParseEntriesFromCSV` to build an `Entries` model from data exported from Daylio with test coverage