### PR TITLE
Add gofmt CI check with Github Actions

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,28 @@
+name: go fmt
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+#    - name: Set up Go
+#      uses: actions/setup-go@v2
+#      with:
+#        go-version: 1.17
+
+#    - name: Copy source
+#      run: cp -r pkg pkg-old
+
+    - name: Check formatting
+      uses: Jerome1337/gofmt-action@v1.0.4
+      with:
+        gofmt-path: './pkg'
+
+#    - name: Check Formatting
+#      run: diff pkg pkg-old


### PR DESCRIPTION
Ensure the code is always formatted with `go fmt` before merging